### PR TITLE
Fix minor bugs in strategy evaluation

### DIFF
--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -263,7 +263,7 @@ class StrategySearcher:
             
         except Exception as e:
             print(f"⚠️ ERROR en evaluación de clusters: {str(e)}")
-            return None
+            return None, None
     
     def check_constant_features(self, X: np.ndarray, feature_cols: list, std_epsilon: float = 1e-12) -> bool:
         """Verifica si hay columnas que podrían causar inestabilidad numérica.

--- a/studies/modules/labeling_lib.py
+++ b/studies/modules/labeling_lib.py
@@ -243,7 +243,6 @@ def approximate_entropy(x):
         return 0.0
     sd = std_manual(x)
     r = 0.2 * sd
-    r *= sd
     count = 0
     for i in range(n - 1):
         for j in range(n - 1):


### PR DESCRIPTION
## Summary
- ensure `_evaluate_clusters` always returns a tuple
- correct radius computation in `approximate_entropy`

## Testing
- `python -m py_compile studies/modules/StrategySearcher.py`
- `python -m py_compile studies/modules/labeling_lib.py`
- `python -m py_compile sqai/genetic_algorithm.py studies/modules/StrategySearcher.py studies/modules/labeling_lib.py studies/modules/tester_lib.py studies/modules/export_lib.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e39416088332a4f97132a8fd6293