### PR TITLE
Fix CatBoost parser name

### DIFF
--- a/studies/modules/export_lib.py
+++ b/studies/modules/export_lib.py
@@ -9,7 +9,7 @@ from onnx.helper import get_attribute_value
 from catboost.utils import convert_to_onnx_object
     
 # ONNX para Pipeline con Catboost
-def skl2onnx_parser_castboost_classifier(scope, model, inputs, custom_parsers=None):
+def skl2onnx_parser_catboost_classifier(scope, model, inputs, custom_parsers=None):
     options = scope.get_options(model, dict(zipmap=True))
     no_zipmap = isinstance(options["zipmap"], bool) and not options["zipmap"]
     
@@ -59,7 +59,7 @@ def export_model_to_ONNX(**kwargs):
         "CatBoostClassifier",
         calculate_linear_classifier_output_shapes,
         skl2onnx_convert_catboost,
-        parser=skl2onnx_parser_castboost_classifier,
+        parser=skl2onnx_parser_catboost_classifier,
         options={"nocl": [True, False], "zipmap": [True, False]}
     )
 

--- a/studies/modules/tester_lib.py
+++ b/studies/modules/tester_lib.py
@@ -11,7 +11,7 @@ from skl2onnx import convert_sklearn, update_registered_converter
 from skl2onnx.common.data_types import FloatTensorType
 from skl2onnx.common.shape_calculator import calculate_linear_classifier_output_shapes
 from modules.export_lib import (
-    skl2onnx_parser_castboost_classifier,
+    skl2onnx_parser_catboost_classifier,
     skl2onnx_convert_catboost,
 )
 rt.set_default_logger_severity(4)
@@ -421,7 +421,7 @@ update_registered_converter(
     "CatBoostClassifier",
     calculate_linear_classifier_output_shapes,
     skl2onnx_convert_catboost,
-    parser=skl2onnx_parser_castboost_classifier,
+    parser=skl2onnx_parser_catboost_classifier,
     options={"nocl": [True, False], "zipmap": [True, False]}
 )
 


### PR DESCRIPTION
## Summary
- rename `skl2onnx_parser_castboost_classifier` to `skl2onnx_parser_catboost_classifier`
- update imports and registration calls

## Testing
- `pip install numpy pandas catboost optuna scikit-learn numba matplotlib onnxruntime skl2onnx hdbscan hmmlearn joblib scipy tqdm memory-profiler`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68548cd3832c83328001f3ea6cd6c0ce