### PR TITLE
Improve memory cleanup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ joblib
 scipy
 tqdm
 memory-profiler
+psutil


### PR DESCRIPTION
## Summary
- add `psutil` for memory tracking
- add `_log_memory` helper
- cleanup temporary frames in `_evaluate_clusters` and `fit_final_models`
- delete datasets in search methods and log memory usage
- run garbage collection in `get_train_test_data`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dc06949c8332a7bdf04a16489a13