### PR TITLE
Unify tester function for both directions

### DIFF
--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -24,7 +24,6 @@ from modules.labeling_lib import (
 )
 from modules.tester_lib import (
     tester,
-    tester_one_direction,
     robust_oos_score_one_direction,
     _ONNX_CACHE
 )
@@ -519,20 +518,28 @@ class StrategySearcher:
             close_train_eval = ds_train_eval_sample['close'].to_numpy()
             close_test_eval = ds_test['close'].to_numpy()
             if self.direction == 'both':
-                df_ins = pd.DataFrame({
-                    'close': close_train_eval,
-                    'labels_main': model_main.predict_proba(ds_train_eval_main)[:, 1],
-                    'labels_meta': model_meta.predict_proba(ds_train_eval_meta)[:, 1],
-                })
-                df_oos = pd.DataFrame({
-                    'close': close_test_eval,
-                    'labels_main': model_main.predict_proba(ds_test_eval_main)[:, 1],
-                    'labels_meta': model_meta.predict_proba(ds_test_eval_meta)[:, 1],
-                })
-                score_ins = tester(df_ins, plot=False)
-                score_oos = tester(df_oos, plot=False)
+                score_ins = tester(
+                    ds_main=ds_train_eval_main,
+                    ds_meta=ds_train_eval_meta,
+                    close=close_train_eval,
+                    model_main=model_main,
+                    model_meta=model_meta,
+                    direction='both',
+                    plot=False,
+                    prd='insample',
+                )
+                score_oos = tester(
+                    ds_main=ds_test_eval_main,
+                    ds_meta=ds_test_eval_meta,
+                    close=close_test_eval,
+                    model_main=model_main,
+                    model_meta=model_meta,
+                    direction='both',
+                    plot=False,
+                    prd='outofsample',
+                )
             else:
-                score_ins = tester_one_direction(
+                score_ins = tester(
                     ds_main=ds_train_eval_main,
                     ds_meta=ds_train_eval_meta,
                     close=close_train_eval,
@@ -542,7 +549,7 @@ class StrategySearcher:
                     plot=False,
                     prd='insample',
                 )
-                score_oos = tester_one_direction(
+                score_oos = tester(
                     ds_main=ds_test_eval_main,
                     ds_meta=ds_test_eval_meta,
                     close=close_test_eval,


### PR DESCRIPTION
## Summary
- refactor `tester` to support both one- and two-direction strategies
- delegate `tester_one_direction` to the unified tester
- adjust `test_model` wrapper to the new interface
- update `StrategySearcher` to use the unified tester

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856de8a16f48332beb69b3e597d056d