### PR TITLE
Reduce memory usage during search

### DIFF
--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -189,6 +189,9 @@ class StrategySearcher:
                                     study.set_user_attr("best_periods_meta", trial.user_attrs.get('periods_meta'))
                                     study.set_user_attr("best_stats_main", trial.user_attrs['stats_main'])
                                     study.set_user_attr("best_stats_meta", trial.user_attrs.get('stats_meta'))
+                            # Liberar memoria eliminando datos pesados del trial
+                            trial.set_user_attr('models', None)
+                            trial.set_user_attr('scores', None)
 
                         # Log
                         if study.best_trials:


### PR DESCRIPTION
## Summary
- clear heavy user attributes after each trial to avoid leaking models
- keep best trial data but free the rest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857209e85e48332881e541ac6080d4b