### PR TITLE
Remove deterministic labeling

### DIFF
--- a/studies/modules/README.md
+++ b/studies/modules/README.md
@@ -29,7 +29,11 @@ The file `labeling_lib.py` exposes a variety of `get_labels_*` functions. Each o
 
 ## Using `StrategySearcher`
 
-`StrategySearcher` now accepts a `label_method` parameter. This string selects any of the functions above via an internal map. By default it uses `"atr"` which maps to `get_labels_one_direction`.
+`StrategySearcher` accepts a `label_method` parameter. This string selects any of the labeling functions above via an internal map. By default it uses `"atr"` which maps to `get_labels_one_direction`.
+
+Label generation is always stochastic when a look-ahead window is involved. Previous deterministic behaviour has been removed and all labeling functions that required a random choice of future bar now select it randomly.
+
+The parameters `markup`, `label_max` and `atr_period` are suggested by Optuna only when the chosen labeling function defines arguments with those names. For example `get_labels_one_direction` and the mean reversion variants all require `markup` and a forward looking window (`max_val`/`max_l`). Trend based labelers usually only use a smoothing window and threshold, so those hyperparameters are ignored during optimization.
 
 Example:
 

--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -77,7 +77,6 @@ class StrategySearcher:
         history_path: str = r"/mnt/c/Users/Administrador/AppData/Roaming/MetaQuotes/Terminal/Common/Files/",
         search_type: str = 'clusters',
         search_subtype: str = 'simple',
-        labels_deterministic: bool = False,
         label_method: str = 'atr',
         tag: str = "",
     ):
@@ -95,7 +94,6 @@ class StrategySearcher:
         self.history_path = history_path
         self.search_type = search_type
         self.search_subtype = search_subtype
-        self.labels_deterministic = labels_deterministic
         self.label_method = label_method
         self.pruner_type = pruner_type
         self.n_trials = n_trials
@@ -122,8 +120,6 @@ class StrategySearcher:
             kwargs['direction'] = self.direction if self.direction != 'both' else 'both'
         if 'atr_period' in params:
             kwargs['atr_period'] = hp['atr_period']
-        if 'deterministic' in params:
-            kwargs['deterministic'] = self.labels_deterministic
         return label_func(dataset, **kwargs)
 
     def _log_memory(self) -> float:

--- a/tests/test_strategy_searcher.py
+++ b/tests/test_strategy_searcher.py
@@ -23,7 +23,6 @@ class DummySearcher(StrategySearcher):
         self.history_path = ""
         self.search_type = "lgmm"
         self.search_subtype = "simple"
-        self.labels_deterministic = False
         self.label_method = "atr"
         self.pruner_type = "hyperband"
         self.n_trials = 1
@@ -65,7 +64,6 @@ class DummySearcherConstant(StrategySearcher):
         self.history_path = ""
         self.search_type = "lgmm"
         self.search_subtype = "simple"
-        self.labels_deterministic = False
         self.label_method = "atr"
         self.pruner_type = "hyperband"
         self.n_trials = 1


### PR DESCRIPTION
## Summary
- remove deterministic argument from labeling functions
- drop StrategySearcher.labels_deterministic usage
- update tests accordingly
- document stochastic labeling usage and Optuna hyperparameters

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q mapie`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858397d74408332aa7655666dd83bbb