### PR TITLE
Add additional stats for feature engineering

### DIFF
--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -376,6 +376,7 @@ class StrategySearcher:
                 "slope", "momentum", "autocorr", "max_dd", "hurst", "corr_skew",
                 "sharpe", "fisher", "chande", "var", "eff_ratio", "kurt",
                 "jump_vol", "fractal", "vol_skew", "approx_entropy",
+                "mean", "median", "iqr", "cv",
             ]
             params = {
                 'cat_main_iterations': trial.suggest_int('cat_main_iterations', 100, 1000),

--- a/studies/modules/export_lib.py
+++ b/studies/modules/export_lib.py
@@ -197,6 +197,18 @@ def export_model_to_ONNX(**kwargs):
                         return tmp[n/2];
                 }
                 """,
+            "iqr": """
+                double stat_iqr(const double &a[])
+                {
+                    double tmp[];
+                    ArrayCopy(tmp, a);
+                    ArraySort(tmp);
+                    int n = ArraySize(tmp);
+                    int q1 = int((n-1)*0.25);
+                    int q3 = int((n-1)*0.75);
+                    return tmp[q3] - tmp[q1];
+                }
+                """,
             "mad": """
                 double stat_mad(const double &a[])
                 {
@@ -215,6 +227,15 @@ def export_model_to_ONNX(**kwargs):
                     for(int i = 0; i < ArraySize(a); i++)
                         sum += (a[i] - mean) * (a[i] - mean);
                     return sum / (ArraySize(a));
+                }
+                """,
+            "cv": """
+                double stat_cv(const double &a[])
+                {
+                    double mean = stat_mean(a);
+                    if(mean == 0.0) return 0.0;
+                    double sd = stat_std(a);
+                    return sd/mean;
                 }
                 """,
             "entropy": """

--- a/studies/modules/labeling_lib.py
+++ b/studies/modules/labeling_lib.py
@@ -312,6 +312,25 @@ def median_manual(a):
         return 0.5 * (b[mid-1] + b[mid])
 
 @njit(cache=True, nogil=True, fastmath=True)
+def iqr_manual(a):
+    n = a.size
+    if n == 0:
+        return 0.0
+    b = a.copy()
+    b.sort()
+    q1_idx = int(0.25 * (n - 1))
+    q3_idx = int(0.75 * (n - 1))
+    return b[q3_idx] - b[q1_idx]
+
+@njit(cache=True, nogil=True, fastmath=True)
+def coeff_var_manual(a):
+    m = mean_manual(a)
+    if m == 0:
+        return 0.0
+    s = std_manual(a)
+    return s / m
+
+@njit(cache=True, nogil=True, fastmath=True)
 def jump_volatility_manual(x):
     if x.size < 2:
         return 0.0
@@ -364,6 +383,14 @@ def compute_features(close, periods_main, periods_meta, stats_main, stats_meta):
                         features[i, col] = zscore_manual(window)
                     elif s == "range":
                         features[i, col] = np.max(window) - np.min(window)
+                    elif s == "mean":
+                        features[i, col] = mean_manual(window)
+                    elif s == "median":
+                        features[i, col] = median_manual(window)
+                    elif s == "iqr":
+                        features[i, col] = iqr_manual(window)
+                    elif s == "cv":
+                        features[i, col] = coeff_var_manual(window)
                     elif s == "mad":
                         m = mean_manual(window)
                         features[i, col] = mean_manual(np.abs(window - m))
@@ -421,6 +448,14 @@ def compute_features(close, periods_main, periods_meta, stats_main, stats_meta):
                             features[i, col] = zscore_manual(window)
                         elif s == "range":
                             features[i, col] = np.max(window) - np.min(window)
+                        elif s == "mean":
+                            features[i, col] = mean_manual(window)
+                        elif s == "median":
+                            features[i, col] = median_manual(window)
+                        elif s == "iqr":
+                            features[i, col] = iqr_manual(window)
+                        elif s == "cv":
+                            features[i, col] = coeff_var_manual(window)
                         elif s == "mad":
                             m = mean_manual(window)
                             features[i, col] = mean_manual(np.abs(window - m))


### PR DESCRIPTION
## Summary
- implement IQR and coefficient of variation utilities
- expose mean, median, IQR and CV statistics for feature engineering
- allow Optuna to choose the new statistics
- generate MQL5 equivalents for IQR and CV

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858596b0a1c83328e3e65de6067a9f9