### PR TITLE
Update labeling thresholds to ATR-based markup

### DIFF
--- a/studies/modules/README.md
+++ b/studies/modules/README.md
@@ -10,16 +10,16 @@ The file `labeling_lib.py` exposes a variety of `get_labels_*` functions. Each o
 | --- | --- |
 | `get_labels_one_direction` | ATR‑based labeling of long/short trades within a look‑ahead window. Can label one or both directions. |
 | `get_labels_trend` | Labels trades when the price trend normalized by volatility exceeds a threshold. |
-| `get_labels_trend_with_profit` | Like `get_labels_trend` but only keeps signals that achieve a minimum markup within a future window. |
-| `get_labels_trend_with_profit_different_filters` | Trend labeling with multiple smoothing methods (savgol, spline, etc.). |
-| `get_labels_trend_with_profit_multi` | Combines several smoothing windows and requires a markup to be hit. |
-| `get_labels_clusters` | Uses K‑Means clusters of closing prices and labels when switching clusters with sufficient price movement. |
+| `get_labels_trend_with_profit` | Like `get_labels_trend` but only keeps signals that achieve a minimum markup (ATR multiple) within a future window. |
+| `get_labels_trend_with_profit_different_filters` | Trend labeling with multiple smoothing methods (savgol, spline, etc.) and ATR-based markup. |
+| `get_labels_trend_with_profit_multi` | Combines several smoothing windows and requires a markup (ATR multiple) to be hit. |
+| `get_labels_clusters` | Uses K‑Means clusters of closing prices and labels when switching clusters with sufficient price movement (markup * ATR). |
 | `get_labels_multi_window` | Generates breakout labels from multiple support/resistance windows. |
 | `get_labels_validated_levels` | Similar to `get_labels_multi_window` but requires several touches to validate levels. |
 | `get_labels_filter_ZZ` | Zigzag peak/trough detection to label local highs and lows. |
-| `get_labels_mean_reversion` | Mean‑reversion labeling based on deviations from a smoothed trend. |
-| `get_labels_mean_reversion_multi` | Mean‑reversion using multiple smoothing windows. |
-| `get_labels_mean_reversion_v` | Mean‑reversion with volatility bands to adapt quantiles. |
+| `get_labels_mean_reversion` | Mean‑reversion labeling based on deviations from a smoothed trend. | Uses markup multiplied by ATR.
+| `get_labels_mean_reversion_multi` | Mean‑reversion using multiple smoothing windows. | Uses markup multiplied by ATR.
+| `get_labels_mean_reversion_v` | Mean‑reversion with volatility bands to adapt quantiles. | Uses markup multiplied by ATR.
 | `get_labels_filter` | Generates labels when price deviates from a Savitzky–Golay filter. |
 | `get_labels_multiple_filters` | Combines several filters and rolling quantiles for multi‑timeframe signals. |
 | `get_labels_filter_bidirectional` | Uses two Savitzky–Golay filters (forward/backward) and labels when price deviates from both. |

--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -506,7 +506,8 @@ class StrategySearcher:
             label_params = inspect.signature(label_func).parameters
 
             if 'markup' in label_params:
-                params['markup'] = trial.suggest_float('markup', 0.1, 1.0, log=True)
+                # markup now acts as a multiplier of the ATR
+                params['markup'] = trial.suggest_float('markup', 0.2, 2.0, log=True)
 
             if 'max_val' in label_params or 'max_l' in label_params:
                 params['label_max'] = trial.suggest_int('label_max', 1, 15, log=True)


### PR DESCRIPTION
## Summary
- compute ATR from OHLC data even when high/low are missing
- apply dynamic markup (`markup * ATR`) in trend, cluster and mean-reversion labelers
- expose `atr_period` for these labeling helpers
- document new behaviour in module README
- fix dynamic markup calculation in `calculate_labels`
- widen Optuna search space for markup

## Testing
- `python -m py_compile studies/modules/labeling_lib.py studies/modules/StrategySearcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685937d8779483328309adb9d4fb340d