### PR TITLE
Add causal search hyperparameter

### DIFF
--- a/studies/modules/README.md
+++ b/studies/modules/README.md
@@ -73,3 +73,10 @@ searcher = StrategySearcher(
     search_type="lgmm",
 )
 ```
+
+### Causal search type
+
+The causal mode attempts to detect bad samples using bootstrapped models
+before training the main strategy. Set `search_type="causal"` to enable it.
+The number of bootstrap learners is controlled by the `n_meta_learners`
+hyperparameter suggested by Optuna (default range 5‑30).

--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -635,6 +635,10 @@ class StrategySearcher:
                     'mapie_confidence_level': trial.suggest_float('mapie_confidence_level', 0.7, 0.99),
                     'mapie_cv': trial.suggest_int('mapie_cv', 3, 10),
                 })
+            elif self.search_type == 'causal':
+                params.update({
+                    'n_meta_learners': trial.suggest_int('n_meta_learners', 5, 30),
+                })
             # Actualizar trial.params con los valores procesados
             for key, value in params.items():
                 trial.set_user_attr(key, value)

--- a/tests/test_strategy_searcher.py
+++ b/tests/test_strategy_searcher.py
@@ -177,3 +177,35 @@ def test_get_train_test_data_prunes_hp():
     assert hp["periods_meta"] == (6,)
     assert hp["stats_meta"] == ("std",)
 
+
+class DummySearcherCausal(StrategySearcher):
+    def __init__(self):
+        self.symbol = "TEST"
+        self.timeframe = "M1"
+        self.direction = "buy"
+        self.train_start = datetime(2020, 1, 1)
+        self.train_end = datetime(2020, 1, 2)
+        self.test_start = datetime(2020, 1, 3)
+        self.test_end = datetime(2020, 1, 4)
+        self.models_export_path = ""
+        self.include_export_path = ""
+        self.history_path = ""
+        self.search_type = "causal"
+        self.search_subtype = "simple"
+        self.label_method = "atr"
+        self.pruner_type = "hyperband"
+        self.n_trials = 1
+        self.n_models = 1
+        self.n_jobs = 1
+        self.tag = ""
+        self.base_df = pd.DataFrame({"close": [1, 2, 3, 4]},
+                                    index=pd.date_range("2020-01-01", periods=4))
+
+
+def test_suggest_all_params_causal_includes_meta_learners():
+    searcher = DummySearcherCausal()
+    study = optuna.create_study(direction="maximize")
+    trial = study.ask()
+    params = searcher.suggest_all_params(trial)
+    assert "n_meta_learners" in params
+


### PR DESCRIPTION
## Summary
- support causal search type in StrategySearcher
- document n_meta_learners in module README
- test new parameter is suggested

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b511ad608332b3d61c0c85995998