### PR TITLE
Add tests for trend labeling

### DIFF
--- a/tests/test_labeling_directions.py
+++ b/tests/test_labeling_directions.py
@@ -51,3 +51,16 @@ def test_trend_one_direction_sell():
         direction="sell",
     )
     assert set(res["labels_main"].unique()) <= {0.0, 1.0}
+
+
+def test_trend_one_direction_buy():
+    df = _sample_df()
+    res = get_labels_trend_one_direction(
+        df,
+        rolling=5,
+        polyorder=2,
+        threshold=0.01,
+        vol_window=5,
+        direction="buy",
+    )
+    assert set(res["labels_main"].unique()) <= {0.0, 1.0}

--- a/tests/test_labeling_trend.py
+++ b/tests/test_labeling_trend.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "studies"))
+
+from modules.labeling_lib import get_labels_trend
+
+
+def _sample_df(n=50):
+    return pd.DataFrame({"close": np.linspace(1, 10, n)})
+
+
+def test_get_labels_trend():
+    df = _sample_df()
+    res = get_labels_trend(
+        df,
+        rolling=5,
+        polyorder=2,
+        threshold=0.01,
+        vol_window=5,
+    )
+    assert not res.empty
+    assert set(res["labels"].unique()) <= {0.0, 1.0, 2.0}


### PR DESCRIPTION
## Summary
- test labeling with trend method
- check single and both-direction labels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859b962a81c8332a91808be92aade89