### PR TITLE
Fix multi-window labeling truncation

### DIFF
--- a/studies/modules/labeling_lib.py
+++ b/studies/modules/labeling_lib.py
@@ -1014,7 +1014,8 @@ def get_labels_multi_window(dataset, window_sizes=[20, 50, 100], threshold_pct=0
     window_sizes_t = List(window_sizes)
     signals = calculate_signals(prices, window_sizes_t, threshold_pct)
     signals = [2.0] * max(window_sizes) + signals
-    dataset['labels'] = signals
+    dataset = dataset.iloc[: len(signals)].copy()
+    dataset['labels'] = signals[: len(dataset)]
     dataset = dataset.drop(dataset[dataset.labels == 2.0].index)
     return dataset
 

--- a/tests/test_labeling_multi_window.py
+++ b/tests/test_labeling_multi_window.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "studies"))
+
+from modules.labeling_lib import get_labels_multi_window
+
+
+def _sample_ohlc_df(n=10):
+    close = np.linspace(1, 10, n)
+    return pd.DataFrame({
+        "close": close,
+        "high": close + 0.5,
+        "low": close - 0.5,
+    })
+
+
+def test_multi_window_small_df():
+    df = _sample_ohlc_df()
+    res = get_labels_multi_window(df)
+    assert len(res) == len(res["labels"])


### PR DESCRIPTION
## Summary
- ensure `get_labels_multi_window` does not assign signals longer than dataset
- add regression test for small datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9d8f16dc83329a485d47eed3ade7