### PR TITLE
Fix polyorder hyperparameter check

### DIFF
--- a/studies/modules/StrategySearcher.py
+++ b/studies/modules/StrategySearcher.py
@@ -667,7 +667,7 @@ class StrategySearcher:
             if 'rolling' in label_params:
                 params['rolling'] = trial.suggest_int('rolling', 20, 400, log=True)
                 # Ajuste para cumplir la condición rolling > polyorder
-                if params['rolling'] <= params['polyorder']:
+                if 'polyorder' in label_params and params['rolling'] <= params['polyorder']:
                     params['rolling'] = params['polyorder'] + 2 + (params['polyorder'] % 2)
 
             if 'threshold' in label_params:


### PR DESCRIPTION
## Summary
- prevent `suggest_all_params` from reading `params['polyorder']` when the label function doesn't define it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685da1c2b9508332bb9fe5549bf30a98