### PR TITLE
Incorporar precio target a funciones de etiquetado

### DIFF
--- a/labeling_lib_changes_summary.md
+++ b/labeling_lib_changes_summary.md
@@ -1,0 +1,107 @@
+# Resumen de Implementación de ATR * Markup en Funciones de Etiquetado
+
+## Análisis Realizado
+
+Se ha realizado un análisis exhaustivo de todas las funciones de etiquetado en `labeling_lib.py` para determinar la necesidad e implementación del precio target basado en `ATR * markup`.
+
+## Funciones Modificadas ✅
+
+### 1. `get_labels_trend` y `calculate_labels_trend`
+- **Cambio**: Incorporación de profit target usando `ATR * markup`
+- **Justificación**: La función básica de tendencia no consideraba volatilidad, generando señales falsas
+- **Nuevos parámetros**: `label_markup`, `label_min_val`, `label_max_val`, `label_atr_period`
+- **Implementación**: Validación de profit futuro con `dyn_mk = label_markup * atr[i]`
+
+### 2. `get_labels_multi_window` y `calculate_labels_multi_window`
+- **Cambio**: Reemplazo de umbrales porcentuales fijos por ATR dinámico
+- **Justificación**: Los umbrales fijos no se adaptan a la volatilidad del mercado
+- **Nuevos parámetros**: `label_markup`, `label_min_val`, `label_max_val`, `label_atr_period`
+- **Implementación**: Uso de `current_price > resistance + dyn_mk` en lugar de porcentajes
+
+### 3. `get_labels_validated_levels` y `calculate_labels_validated_levels`
+- **Cambio**: Incorporación de ATR para detección de toques y rupturas de niveles
+- **Justificación**: Umbrales porcentuales fijos generaban señales inconsistentes
+- **Nuevos parámetros**: `label_markup`, `label_min_val`, `label_max_val`, `label_atr_period`
+- **Implementación**: Toques de nivel con `abs(current_price - level) <= dyn_mk`
+
+### 4. `get_labels_filter_zigzag` y `calculate_labels_zigzag`
+- **Cambio**: Validación de profit para señales de peaks/troughs
+- **Justificación**: Los patrones zigzag necesitan confirmación de efectividad
+- **Nuevos parámetros**: `label_markup`, `label_min_val`, `label_max_val`, `label_atr_period`
+- **Implementación**: Validación bidireccional con profit target dinámico
+
+### 5. `get_labels_fractal_patterns`
+- **Cambio**: Escalado de markup_points por ATR
+- **Justificación**: Markup fijo no se adapta a diferentes condiciones de volatilidad
+- **Nuevos parámetros**: `label_atr_period` (cambió `label_markup` de 0.00010 a 0.5)
+- **Implementación**: Nueva función `calculate_future_outcome_labels_for_patterns_atr`
+
+## Funciones que YA implementaban ATR * markup ✅
+
+1. `get_labels_trend_with_profit`
+2. `get_labels_trend_with_profit_different_filters`
+3. `get_labels_trend_with_profit_multi`
+4. `get_labels_clusters`
+5. `get_labels_mean_reversion`
+6. `get_labels_mean_reversion_multi`
+7. `get_labels_mean_reversion_vol`
+8. `get_labels_random`
+
+## Funciones que NO requieren ATR * markup ❌
+
+### Funciones de Filtro Básico
+- `get_labels_filter`
+- `get_labels_multiple_filters`
+- `get_labels_filter_bidirectional`
+
+**Justificación**: Se basan en desviación de precios respecto a filtros, no en predicción de movimientos futuros.
+
+### Funciones de Clustering y Régimen
+- `sliding_window_clustering`
+- `clustering_simple`
+- `markov_regime_switching_*`
+- `lgmm_clustering`
+- `wkmeans_clustering`
+
+**Justificación**: Se enfocan en detectar regímenes de mercado, no generan señales direccionales.
+
+## Metodología Implementada
+
+### Convención de Parámetros
+Todas las funciones modificadas siguen la convención metodológica estándar:
+
+```python
+label_markup=0.5          # Multiplicador de ATR
+label_min_val=1          # Horizonte mínimo en barras
+label_max_val=15         # Horizonte máximo en barras
+label_atr_period=14      # Período para cálculo de ATR
+```
+
+### Procedimiento de Cálculo
+1. **Cálculo de ATR**: `atr = calculate_atr_simple(high, low, close, period=label_atr_period)`
+2. **Target dinámico**: `dyn_mk = label_markup * atr[i]`
+3. **Validación temporal**: `rand = np.random.randint(label_min_val, label_max_val + 1)`
+4. **Verificación de profit**: `future_price >= current_price + dyn_mk` (buy) o `future_price <= current_price - dyn_mk` (sell)
+
+### Transferencia de Datos
+- Funciones principales (no-jit) preparan datos y calculan ATR
+- Funciones auxiliares (jit) reciben arrays numpy para maximizar rendimiento
+- Sincronización correcta de datos entre función principal y auxiliar
+
+## Coherencia con Metodología de Etiquetado
+
+### Direccionalidad
+- `direction=0`: Solo buy (1.0=éxito, 0.0=fracaso, 2.0=no confiable)
+- `direction=1`: Solo sell (1.0=éxito, 0.0=fracaso, 2.0=no confiable)
+- `direction=2`: Ambas (0.0=buy, 1.0=sell, 2.0=no señal)
+
+### Validación de Profit
+- Todas las funciones modificadas validan señales con movimientos futuros
+- Solo se etiquetan como exitosas (0.0/1.0) las señales que alcanzan el target
+- Señales que no alcanzan target se marcan como 2.0 (no confiable)
+
+## Verificación
+✅ Compilación exitosa sin errores de sintaxis
+✅ Funciones auxiliares mantenidas con `@njit(cache=True)` para rendimiento
+✅ Coherencia en nombres de parámetros y metodología
+✅ Transferencia eficiente de datos entre funciones principal y auxiliar


### PR DESCRIPTION
Integrate ATR-based profit targets into key labeling functions to enhance volatility adaptation.

Previously, several labeling functions relied on fixed percentage thresholds or unscaled markups, which limited their effectiveness across varying market volatilities. This PR updates `get_labels_trend`, `get_labels_multi_window`, `get_labels_validated_levels`, `get_labels_filter_zigzag`, and `get_labels_fractal_patterns` to use a dynamic `ATR * markup` for profit target calculation, ensuring more robust and consistent labels.