### PR TITLE
Revisar y corregir algoritmo de búsqueda de estrategias

### DIFF
--- a/studies/modules/tester_lib.py
+++ b/studies/modules/tester_lib.py
@@ -21,12 +21,12 @@ def tester(
         model_meta_threshold: float = 0.5,
         model_max_orders: int = 1,
         model_delay_bars: int = 1,
-        debug: bool = False) -> tuple[float, pd.DataFrame]:
+        debug: bool = False) -> float:
     """
     Evalúa una estrategia para una o ambas direcciones, usando ejecución realista:
-    - Las operaciones se abren y cierran al precio 'open' de la barra actual (índice t),
-      ya que las features y señales de t son válidas para operar en t.
-    - Solo se pasan los arrays estrictamente necesarios a la función jiteada backtest.
+         - Las operaciones se abren y cierran al precio 'open' de la barra siguiente (t+1),
+       porque las predicciones de t solo pueden ejecutarse en t+1 (sin lookahead).
+     - Solo se pasan los arrays estrictamente necesarios a la función jiteada backtest.
 
     Parameters
     ----------
@@ -54,6 +54,14 @@ def tester(
             main = main[0]
         if meta.ndim > 1:
             meta = meta[0]
+
+        # Shift predictions by 1 bar to avoid lookahead
+        if main.shape[0] > 0:
+            main = np.roll(main, 1)
+            main[0] = 0.0
+        if meta.shape[0] > 0:
+            meta = np.roll(meta, 1)
+            meta[0] = 0.0
 
         dataset['labels_main'] = main.astype(float)
         dataset['labels_meta'] = meta.astype(float)


### PR DESCRIPTION
Correct lookahead issues and improve evaluation robustness in the trading strategy search algorithm.

The changes address several methodological and logical flaws: The backtester previously used signals from time `t` to operate at time `t`, which constituted lookahead; signals are now shifted to `t+1`. Model scoring for Optuna trials was done on the full dataset, potentially including the test period, leading to an overoptimistic score; it's now strictly on the designated test subset. Early stopping validation data was not clearly separated from the final test set, which is now fixed by creating an in-sample train/validation split. Minor fixes for meta-feature handling and Optuna configuration are also included.

---
<a href="https://cursor.com/background-agent?bcId=bc-79dc9c90-788c-47f3-98b5-1656bd237765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79dc9c90-788c-47f3-98b5-1656bd237765">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

